### PR TITLE
Fix documentation links to use 'master' branch instead of 'main'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -375,11 +375,11 @@ SELECT * FROM word</code></pre>
             <h2>Documentation</h2>
             <p>For detailed information about the concepts and architecture:</p>
             <ul>
-                <li><a href="https://github.com/questrel/dtree/blob/main/CONCEPTS.md" target="_blank">CONCEPTS.md</a> - Detailed explanation of dtree concepts and components</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/QUICKSTART.md" target="_blank">QUICKSTART.md</a> - Quick start guide with installation instructions</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> - Contributor guidelines</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/CODE_OF_CONDUCT.md" target="_blank">CODE_OF_CONDUCT.md</a> - Community code of conduct</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/LICENSE" target="_blank">LICENSE</a> - Project license information</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/CONCEPTS.md" target="_blank">CONCEPTS.md</a> - Detailed explanation of dtree concepts and components</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/QUICKSTART.md" target="_blank">QUICKSTART.md</a> - Quick start guide with installation instructions</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> - Contributor guidelines</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/CODE_OF_CONDUCT.md" target="_blank">CODE_OF_CONDUCT.md</a> - Community code of conduct</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/LICENSE" target="_blank">LICENSE</a> - Project license information</li>
             </ul>
         </section>
 
@@ -430,8 +430,8 @@ SELECT * FROM word</code></pre>
 
         <section id="contributing" class="section">
             <h2>Contributing</h2>
-            <p>Contributions are welcome! Please see <a href="https://github.com/questrel/dtree/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> for guidelines.</p>
-            <p>All contributors are expected to abide by the <a href="https://github.com/questrel/dtree/blob/main/CODE_OF_CONDUCT.md" target="_blank">code of conduct</a>.</p>
+            <p>Contributions are welcome! Please see <a href="https://github.com/questrel/dtree/blob/master/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> for guidelines.</p>
+            <p>All contributors are expected to abide by the <a href="https://github.com/questrel/dtree/blob/master/CODE_OF_CONDUCT.md" target="_blank">code of conduct</a>.</p>
         </section>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -375,11 +375,11 @@ SELECT * FROM word</code></pre>
             <h2>Documentation</h2>
             <p>For detailed information about the concepts and architecture:</p>
             <ul>
-                <li><a href="https://github.com/questrel/dtree/blob/main/CONCEPTS.md" target="_blank">CONCEPTS.md</a> - Detailed explanation of dtree concepts and components</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/QUICKSTART.md" target="_blank">QUICKSTART.md</a> - Quick start guide with installation instructions</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> - Contributor guidelines</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/CODE_OF_CONDUCT.md" target="_blank">CODE_OF_CONDUCT.md</a> - Community code of conduct</li>
-                <li><a href="https://github.com/questrel/dtree/blob/main/LICENSE" target="_blank">LICENSE</a> - Project license information</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/CONCEPTS.md" target="_blank">CONCEPTS.md</a> - Detailed explanation of dtree concepts and components</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/QUICKSTART.md" target="_blank">QUICKSTART.md</a> - Quick start guide with installation instructions</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> - Contributor guidelines</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/CODE_OF_CONDUCT.md" target="_blank">CODE_OF_CONDUCT.md</a> - Community code of conduct</li>
+                <li><a href="https://github.com/questrel/dtree/blob/master/LICENSE" target="_blank">LICENSE</a> - Project license information</li>
             </ul>
         </section>
 
@@ -430,8 +430,8 @@ SELECT * FROM word</code></pre>
 
         <section id="contributing" class="section">
             <h2>Contributing</h2>
-            <p>Contributions are welcome! Please see <a href="https://github.com/questrel/dtree/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> for guidelines.</p>
-            <p>All contributors are expected to abide by the <a href="https://github.com/questrel/dtree/blob/main/CODE_OF_CONDUCT.md" target="_blank">code of conduct</a>.</p>
+            <p>Contributions are welcome! Please see <a href="https://github.com/questrel/dtree/blob/master/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> for guidelines.</p>
+            <p>All contributors are expected to abide by the <a href="https://github.com/questrel/dtree/blob/master/CODE_OF_CONDUCT.md" target="_blank">code of conduct</a>.</p>
         </section>
     </div>
 


### PR DESCRIPTION
Update all GitHub documentation links from 'blob/main' to 'blob/master' to match the repository's actual default branch name. This fixes 404 errors when clicking on documentation links from the GitHub Pages site.

Fixed links for:
- CONCEPTS.md
- QUICKSTART.md
- CONTRIBUTING.md
- CODE_OF_CONDUCT.md
- LICENSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)