### PR TITLE
Fix qtl::string description to improve readability

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -259,7 +259,7 @@
             <div class="concepts-grid">
                 <div class="concept-item">
                     <h3>qtl::string</h3>
-                    <p>Like <code>std::string_view</code>, can contain any std::string while maintaining memcmp ordering.
+                    <p>A string type similar to <code>std::string_view</code> that can contain any std::string while maintaining memcmp ordering.
                     Can also contain out-of-band separator tokens.</p>
                 </div>
                 <div class="concept-item">

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
             <div class="concepts-grid">
                 <div class="concept-item">
                     <h3>qtl::string</h3>
-                    <p>Like <code>std::string_view</code>, can contain any std::string while maintaining memcmp ordering.
+                    <p>A string type similar to <code>std::string_view</code> that can contain any std::string while maintaining memcmp ordering.
                     Can also contain out-of-band separator tokens.</p>
                 </div>
                 <div class="concept-item">


### PR DESCRIPTION
Change "Like std::string_view, can contain..." to "A string type similar to std::string_view that can contain..." to avoid awkward comma placement when text wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)